### PR TITLE
Add amd64 Dockerfile and compose config for Apple Silicon build support #8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM --platform=linux/amd64 node:12-buster
+SHELL ["/bin/bash","-lc"]
+
+# 1. Switch buster mirrors to archive + disable validity check
+RUN sed -i -e 's|deb.debian.org/debian|archive.debian.org/debian|g' \
+           -e 's|security.debian.org/debian-security|archive.debian.org/debian-security|g' \
+           /etc/apt/sources.list \
+ && printf 'Acquire::Check-Valid-Until "false";\n' >/etc/apt/apt.conf.d/99no-check-valid
+
+# 2. Install dependencies (including python2)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    python2 \
+    pkg-config \
+    git \
+    libcairo2-dev \
+    libpango1.0-dev \
+    libjpeg-dev \
+    libgif-dev \
+    librsvg2-dev \
+ && ln -sf /usr/bin/python2 /usr/bin/python \
+ && npm i -g npm@6 \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /work

--- a/README.md
+++ b/README.md
@@ -24,6 +24,55 @@ The software allows you to create the following QR types:
 
 - Node.js 12 LTS
 
+## Docker Setup (Alternative)
+
+For ARM-based Macs or environments where native canvas dependencies fail to build, Docker provides a reliable alternative:
+
+### Prerequisites
+
+- Docker and Docker Compose(v2+) installed on your system
+
+### Using Docker Compose
+
+1. Build and start the development container:
+   ```bash
+   docker-compose up -d dev
+   ```
+
+2. Access the container shell:
+   ```bash
+   docker-compose exec dev bash
+   ```
+
+3. Install dependencies inside the container:
+   ```bash
+   npm install
+   ```
+
+4. Run your development commands:
+   ```bash
+   npm run build
+   npm test
+   ```
+
+The container is configured with:
+- Node.js 12 LTS on Linux AMD64 platform
+- All required native dependencies for canvas compilation
+- Python 2 for native module building
+- Volume mounting for live code editing
+
+### Manual Docker Usage
+
+Alternatively, you can build and run the container manually:
+
+```bash
+# Build the Docker image
+docker build -t symbol-qr-library .
+
+# Run the container with volume mounting
+docker run -it --rm -v $(pwd):/work symbol-qr-library bash
+```
+
 ## Installation
 
 `npm install symbol-qr-library`

--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ For ARM-based Macs or environments where native canvas dependencies fail to buil
 
 1. Build and start the development container:
    ```bash
-   docker-compose up -d dev
+   docker compose up -d dev
    ```
 
 2. Access the container shell:
    ```bash
-   docker-compose exec dev bash
+   docker compose exec dev bash
    ```
 
 3. Install dependencies inside the container:

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,13 @@
+services:
+  dev:
+    build: .
+    platform: linux/amd64   # M1/M2 でも amd64 を強制
+    working_dir: /work
+    volumes:
+      - .:/work:cached
+    environment:
+      - npm_config_python=/usr/bin/python2
+      - npm_config_build_from_source=true
+    tty: true
+    stdin_open: true
+    command: bash

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,4 @@
 var path = require("path");
-var webpack = require("webpack");
 
 var PATHS = {
   entryPoint: path.resolve(__dirname, 'index.ts'),
@@ -29,7 +28,14 @@ var config = {
   // Add resolve for `tsx` and `ts` files, otherwise Webpack would
   // only look for common JavaScript file extension (.js)
   resolve: {
-    extensions: ['.ts', '.tsx', '.js']
+    extensions: ['.ts', '.tsx', '.js'],
+    // Webpack 5 does not automatically polyfill Node.js core modules.
+    // Node polyfills have been moved to explicit fallbacks below.
+    fallback: {
+      fs: false,
+      tls: false,
+      net: false
+    }
   },
   // Activate source maps for the bundles in order to preserve the original
   // source when the user debugs the application
@@ -42,11 +48,6 @@ var config = {
         exclude: /node_modules/,
       },
     ],
-  },
-  node: {
-    fs: 'empty',
-    tls: 'empty',
-    net: 'empty'
   },
   performance: { 
     hints: false


### PR DESCRIPTION
This PR introduces a Docker-based build environment to ensure compatibility on Apple Silicon Macs.

- Added Dockerfile using --platform=linux/amd64 with Node.js 12 (buster)
- Switched Debian buster repositories to archive mirrors and disabled validity checks
- Installed required build dependencies (including Python 2)
- Added compose.yml to run the environment with amd64 platform override

With these changes, the project can be built successfully on Apple Silicon machines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - Docker/Compose を用いた代替開発環境を追加し、ローカル環境構築を簡素化
- ドキュメント
  - README に Docker ベースの開発手順（ビルド、起動、シェルアクセス、依存関係インストール、ビルド/テスト実行）を追記
- チョア
  - 開発コンテナに Node.js 12 相当とビルド依存を導入し、npm バージョン固定や不要ファイル削除で軽量化
  - Compose に対話的な開発サービスを追加し、プロジェクトをマウントしてそのまま作業可能に
- リファクタ
  - ビルド設定を更新し、旧来の自動ポリフィルを明示的に無効化
<!-- end of auto-generated comment: release notes by coderabbit.ai -->